### PR TITLE
style(auth, settings, home): set white color for icons in app bars

### DIFF
--- a/lib/auth/login_page.dart
+++ b/lib/auth/login_page.dart
@@ -21,6 +21,7 @@ class LoginScreen extends StatelessWidget {
           ),
         ),
         backgroundColor: const Color.fromARGB(255, 246, 3, 132),
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),

--- a/lib/auth/ogout_screen.dart
+++ b/lib/auth/ogout_screen.dart
@@ -18,6 +18,7 @@ class LogoutScreen extends StatelessWidget {
           ),
         ),
         backgroundColor: const Color.fromARGB(255, 246, 3, 132),
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),

--- a/lib/home/swipe_card_screen.dart
+++ b/lib/home/swipe_card_screen.dart
@@ -126,6 +126,7 @@ class _SwipeCardScreenState extends State<SwipeCardScreen> {
           ),
         ),
         backgroundColor: const Color.fromARGB(255, 246, 3, 132),
+        iconTheme: const IconThemeData(color: Colors.white),
         leading: IconButton(
           icon: const Icon(Icons.menu), // Burger menu icon
           onPressed: () {

--- a/lib/settings/about_section_screen.dart
+++ b/lib/settings/about_section_screen.dart
@@ -16,6 +16,7 @@ class AboutSectionScreen extends StatelessWidget {
           ),
         ),
         backgroundColor: const Color.fromARGB(255, 246, 3, 132),
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
       body: const Padding(
         padding: EdgeInsets.all(16.0),

--- a/lib/settings/account_settings_screen.dart
+++ b/lib/settings/account_settings_screen.dart
@@ -35,6 +35,7 @@ class _AccountSettingsScreenState extends State<AccountSettingsScreen> {
           ),
         ),
         backgroundColor: const Color.fromARGB(255, 246, 3, 132),
+        iconTheme: const IconThemeData(color: Colors.white),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           onPressed: () {

--- a/lib/settings/privacy_policy_screen.dart
+++ b/lib/settings/privacy_policy_screen.dart
@@ -16,6 +16,7 @@ class PrivacyPolicyScreen extends StatelessWidget {
           ),
         ),
         backgroundColor: const Color.fromARGB(255, 246, 3, 132),
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
       body: const Padding(
         padding: EdgeInsets.all(16.0),

--- a/lib/settings/setting_screen.dart
+++ b/lib/settings/setting_screen.dart
@@ -28,6 +28,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
         ),
         backgroundColor: const Color.fromARGB(255, 246, 3, 132),
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
       body: ListView(
         children: [

--- a/lib/settings/terms_of_service_screen.dart
+++ b/lib/settings/terms_of_service_screen.dart
@@ -16,6 +16,7 @@ class TermsOfServiceScreen extends StatelessWidget {
           ),
         ),
         backgroundColor: const Color.fromARGB(255, 246, 3, 132),
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
       body: const Padding(
         padding: EdgeInsets.all(16.0),


### PR DESCRIPTION
This change ensures consistency in the UI by setting the icon theme color to white across multiple screens, improving visual coherence and readability